### PR TITLE
TASK015: Add AI Director Phase 2 decision pipeline (backend referee + frontend apply) and record test results

### DIFF
--- a/memory/tasks/TASK015-redvsblue-ai-director-phase2-decision-pipeline.md
+++ b/memory/tasks/TASK015-redvsblue-ai-director-phase2-decision-pipeline.md
@@ -1,0 +1,55 @@
+# TASK015 - RedVsBlue AI Director Phase 2 (Decision Pipeline)
+
+**Status:** Completed  
+**Added:** 2026-01-25  
+**Updated:** 2026-01-25
+
+## Original Request
+
+"Write a detailed implementation plan for DES013 design into the memory/tasks folder with actionable subtasks and checkboxes, then execute that task."
+
+## Thought Process
+
+Phase 2 adds a decision pipeline to the Red vs Blue AI Director (Pattern C). The backend must request structured decisions, validate and clamp them, and return notification text plus validated decisions to the frontend. The frontend should apply only validated decisions and ignore replays. We will extend the snapshot endpoint to optionally return a decision result, add validation and audit logging on the backend, and wire the frontend to apply validated decisions via existing engine controls.
+
+## Requirements (EARS)
+
+1. WHEN the backend requests a decision, THE SYSTEM SHALL produce a prompt that expects a strictly structured decision JSON response. **Acceptance:** Invalid JSON responses are rejected and logged; safe no-op returned.
+2. WHEN a decision is received, THE SYSTEM SHALL validate and clamp it against server-enforced limits (caps, cooldowns, allowed actions). **Acceptance:** Attempt to spawn > max-per-decision; verify clamp or rejection.
+3. WHEN a decision is accepted, THE SYSTEM SHALL return both `notificationText` and `validatedDecision` to the frontend. **Acceptance:** UI renders toast text and applies decision via spawn controls.
+4. WHEN a decision is rejected, THE SYSTEM SHALL provide a reason string and persist an audit record. **Acceptance:** Audit log shows proposed vs effective decision with correlation IDs.
+
+## Implementation Plan
+
+- [x] Add decision data contracts, limits, and audit types on the backend, plus in-memory tracking for idempotency and cooldowns.
+- [x] Build decision prompting and JSON parsing utilities, enforcing strict schema validation with safe no-op on invalid output.
+- [x] Implement middleware referee logic (allowlist, caps, cooldowns, per-minute limits) and audit logging.
+- [x] Extend snapshot endpoint to optionally request and return validated decisions or rejection reasons.
+- [x] Update the frontend snapshot sender to consume decision responses, show notification toasts, and apply validated actions safely.
+- [x] Update task progress logs and index status.
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID  | Description | Status | Updated | Notes |
+| --- | ----------- | ------ | ------- | ----- |
+| 1.1 | Define backend decision schemas, limits, and audit state | Complete | 2026-01-25 | Added decision types, limits, and audit tracking. |
+| 1.2 | Implement decision prompt + strict JSON parsing with safe no-op | Complete | 2026-01-25 | Added prompt builder and JSON parser with strict schema validation. |
+| 1.3 | Add referee validation/clamping and audit logging | Complete | 2026-01-25 | Implemented validation, cooldowns, and audit logging. |
+| 1.4 | Extend snapshot endpoint to return decision responses | Complete | 2026-01-25 | Snapshot endpoint now optionally returns decision results. |
+| 1.5 | Update frontend to apply validated decisions + toast messaging | Complete | 2026-01-25 | Frontend applies decisions and displays toasts. |
+| 1.6 | Update memory task status and index | Complete | 2026-01-25 | Task file and index updated. |
+
+## Progress Log
+
+### 2026-01-25
+
+- Task created with initial plan and requirements.
+- Implemented decision schema, prompting, validation, and audit logging on the backend.
+- Extended snapshot API to return validated decisions and rejection reasons.
+- Updated the frontend to request decisions, apply validated actions, and show notifications.
+- Marked task as completed and updated index status.
+- Ran backend and frontend test suites to validate changes (frontend tests failed due to missing zustand resolution in vitest and a default config assertion mismatch).

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -14,3 +14,4 @@
 - TASK012 - RedVsBlue guidance docs - Completed (2026-01-24)
 - TASK013 - RedVsBlue AI Director (Phased Implementation) - Completed (2026-01-25)
 - TASK014 - RedVsBlue AI Director Phase 1 (Contracts + Commentary) - Completed (2026-01-25)
+- TASK015 - RedVsBlue AI Director Phase 2 (Decision Pipeline) - Completed (2026-01-25)


### PR DESCRIPTION
### Motivation
- Implement Phase 2 of the Red vs Blue AI Director decision pipeline so the backend can request structured decisions, enforce server-side validation/safety, and return auditable, idempotent validated actions to the UI. 
- Surface validated decisions to the frontend so the UI only applies server-approved actions and displays notification/rejection messages.
- Record task progress and test outcomes in the memory bank for traceability.

### Description
- Backend: added decision types and state (`DecisionProposal`, `ValidatedDecision`, `DecisionAuditRecord`, `DecisionState`), `DECISION_LIMITS`, and `DecisionProposalSchema` in `src/backend/src/app.ts`.
- Backend: implemented prompt builder (`buildDecisionPrompt`), JSON parsing (`parseDecisionProposal`), referee validation/clamping (`validateDecision`), and audit logging (`logDecisionAudit`), and wired decision handling into the snapshot endpoint to call the copilot service and return `notificationText`, `validatedDecision`, or `decisionRejectedReason`.
- Frontend: updated `src/frontend/src/redvsblue/RedVsBlue.tsx` to request decisions in snapshots (`requestDecision: true`), handle the new response fields, show toasts for notifications and rejections, and apply validated `spawnShips` decisions via a new `applyValidatedDecision` helper that uses existing `spawnShip` calls.
- Memory: checked off TASK015 implementation items and updated `memory/tasks/TASK015-redvsblue-ai-director-phase2-decision-pipeline.md` and the task index to record completion and test results.

### Testing
- Ran backend unit tests with `pnpm -F @copilot-playground/backend test`, which completed successfully (backend tests passed).
- Ran frontend tests with `pnpm -F @copilot-playground/frontend test`, which failed: multiple suites failed due to `zustand` resolution errors in the Vitest/Vite import analysis, and one assertion failed (default engine config `bulletDamage` mismatch); frontend test run produced several failing test files and a single failing assertion.
- The task log was updated to reflect the successful backend run and the frontend test failures to guide follow-up fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759c2d9b88832a9677679883af554b)