### PR TITLE
Add auto-decisions toggle and enforce 30s snapshot cadence for RedVsBlue

### DIFF
--- a/memory/tasks/TASK016-redvsblue-ai-director-phase3-auto-decisions.md
+++ b/memory/tasks/TASK016-redvsblue-ai-director-phase3-auto-decisions.md
@@ -1,0 +1,48 @@
+# TASK016 - RedVsBlue AI Director Phase 3 (Auto-Decisions)
+
+**Status:** Completed  
+**Added:** 2026-01-25  
+**Updated:** 2026-01-25
+
+## Original Request
+
+"Write a detailed implementation plan for DES014 design into the memory/tasks folder with actionable subtasks and checkboxes, then execute that task."
+
+## Thought Process
+
+Phase 3 focuses on periodic snapshots with a user-controlled auto-decisions toggle, plus server-side clamping of the snapshot interval. The plan should update UI controls to let users enable/disable auto-decisions, ensure snapshots only request decisions when the toggle is enabled, and align the frontend and backend snapshot interval defaults and bounds to match the design's 30s cadence while enforcing safety limits. We'll also adjust styles to keep the new control readable and update task tracking once the work is complete.
+
+## Requirements (EARS)
+
+1. WHEN auto-decisions are enabled, THE SYSTEM SHALL request decisions at a controlled cadence from snapshots. **Acceptance:** Enable auto-decisions; confirm decision requests follow the configured snapshot interval.
+2. WHEN auto-decisions are disabled, THE SYSTEM SHALL NOT request or apply gameplay mutations automatically. **Acceptance:** Disable auto-decisions; confirm snapshot payloads omit decision requests and no decisions are applied.
+3. WHEN the snapshot interval is configured by the frontend, THE SYSTEM SHALL validate and clamp it to server-enforced safe bounds. **Acceptance:** Send an interval below the minimum; confirm server clamps to the minimum value and returns the effective config.
+
+## Implementation Plan
+
+- [x] Add auto-decisions toggle state in the Red vs Blue UI and pass it to snapshot payloads.
+- [x] Update controls UI to display the auto-decisions toggle and ensure styling supports the new control.
+- [x] Align frontend and backend snapshot interval defaults and bounds to the Phase 3 cadence (30s default, safe min/max).
+- [x] Update task tracking (status, subtasks, progress log, index).
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID  | Description | Status | Updated | Notes |
+| --- | ----------- | ------ | ------- | ----- |
+| 1.1 | Add auto-decisions toggle state and snapshot gating | Complete | 2026-01-25 | Snapshot payload now respects toggle. |
+| 1.2 | Update controls UI and styles for auto-decisions | Complete | 2026-01-25 | Added toggle control styling. |
+| 1.3 | Update snapshot interval defaults and clamp bounds | Complete | 2026-01-25 | 30s default and safe min/max applied. |
+| 1.4 | Update task status and index | Complete | 2026-01-25 | Task log and index updated. |
+
+## Progress Log
+
+### 2026-01-25
+
+- Added auto-decisions toggle state and gated decision requests in snapshot payloads.
+- Updated Red vs Blue controls UI and styles for the auto-decisions toggle.
+- Adjusted snapshot interval defaults and server clamp ranges to align with Phase 3 cadence.
+- Marked task as completed and updated the task index.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -15,3 +15,4 @@
 - TASK013 - RedVsBlue AI Director (Phased Implementation) - Completed (2026-01-25)
 - TASK014 - RedVsBlue AI Director Phase 1 (Contracts + Commentary) - Completed (2026-01-25)
 - TASK015 - RedVsBlue AI Director Phase 2 (Decision Pipeline) - Completed (2026-01-25)
+- TASK016 - RedVsBlue AI Director Phase 3 (Auto-Decisions) - Completed (2026-01-25)

--- a/src/backend/src/app.ts
+++ b/src/backend/src/app.ts
@@ -161,7 +161,7 @@ const RULE_RANGES = {
 };
 
 const CONFIG_RANGES = {
-  snapshotIntervalMs: { min: 250, max: 10_000, default: 2_000 },
+  snapshotIntervalMs: { min: 5_000, max: 60_000, default: 30_000 },
 };
 
 const MAX_SNAPSHOT_BUFFER = 120;

--- a/src/frontend/src/redvsblue/RedVsBlue.tsx
+++ b/src/frontend/src/redvsblue/RedVsBlue.tsx
@@ -46,6 +46,7 @@ const RedVsBlue: React.FC = () => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [commentary, setCommentary] = useState<string | null>(null);
   const [snapshotIntervalMs, setSnapshotIntervalMs] = useState(DEFAULT_SNAPSHOT_INTERVAL_MS);
+  const [autoDecisionsEnabled, setAutoDecisionsEnabled] = useState(false);
 
   const { spawnShip, reset } = useGame({ canvasRef, containerRef, worker: workerMode });
 
@@ -63,6 +64,14 @@ const RedVsBlue: React.FC = () => {
       setCommentary(null);
     }, DEFAULT_UI_CONFIG.toastTimeoutMs);
   }, []);
+
+  const handleAutoDecisionsToggle = useCallback(
+    (enabled: boolean) => {
+      setAutoDecisionsEnabled(enabled);
+      showToast(enabled ? "Auto-decisions enabled." : "Auto-decisions disabled.");
+    },
+    [showToast]
+  );
 
   const applyValidatedDecision = useCallback(
     (decision: {
@@ -162,7 +171,7 @@ const RedVsBlue: React.FC = () => {
         gameSummary: summary,
         counts: { red: redCount, blue: blueCount },
         recentMajorEvents: [],
-        requestDecision: true,
+        requestDecision: autoDecisionsEnabled,
       };
       void (async () => {
         try {
@@ -199,7 +208,7 @@ const RedVsBlue: React.FC = () => {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [applyValidatedDecision, blueCount, redCount, sessionId, showToast, snapshotIntervalMs]);
+  }, [applyValidatedDecision, autoDecisionsEnabled, blueCount, redCount, sessionId, showToast, snapshotIntervalMs]);
 
   useEffect(() => {
     return () => {
@@ -252,6 +261,8 @@ const RedVsBlue: React.FC = () => {
           onSpawnBlue={() => spawnShip("blue")}
           onReset={reset}
           onAskCopilot={handleAskCopilot}
+          autoDecisionsEnabled={autoDecisionsEnabled}
+          onToggleAutoDecisions={handleAutoDecisionsToggle}
         />
       </div>
       {commentary && (

--- a/src/frontend/src/redvsblue/RedVsBlueControls.tsx
+++ b/src/frontend/src/redvsblue/RedVsBlueControls.tsx
@@ -5,6 +5,8 @@ type RedVsBlueControlsProps = {
   onSpawnBlue: () => void
   onReset: () => void
   onAskCopilot: () => void
+  autoDecisionsEnabled: boolean
+  onToggleAutoDecisions: (enabled: boolean) => void
 }
 
 const RedVsBlueControls: React.FC<RedVsBlueControlsProps> = ({
@@ -12,6 +14,8 @@ const RedVsBlueControls: React.FC<RedVsBlueControlsProps> = ({
   onSpawnBlue,
   onReset,
   onAskCopilot,
+  autoDecisionsEnabled,
+  onToggleAutoDecisions,
 }) => (
   <div className="controls">
     <button className="btn-red" onClick={onSpawnRed}>
@@ -26,6 +30,14 @@ const RedVsBlueControls: React.FC<RedVsBlueControlsProps> = ({
     <button className="btn-copilot" onClick={onAskCopilot}>
       Ask Copilot
     </button>
+    <label className="auto-decisions-toggle">
+      <input
+        type="checkbox"
+        checked={autoDecisionsEnabled}
+        onChange={(event) => onToggleAutoDecisions(event.target.checked)}
+      />
+      Auto-decisions
+    </label>
   </div>
 )
 

--- a/src/frontend/src/redvsblue/RedVsBlueStyles.tsx
+++ b/src/frontend/src/redvsblue/RedVsBlueStyles.tsx
@@ -8,10 +8,12 @@ const RedVsBlueStyles: React.FC = () => (
     .top-bar { background: rgba(0, 0, 0, 0.5); padding: 10px; display: flex; justify-content: center; gap: 40px; font-size: 24px; font-weight: bold; text-shadow: 0 0 5px black; }
     .red-text { color: #ff4d4d; }
     .blue-text { color: #4d4dff; }
-    .controls { pointer-events: auto; background: rgba(0,0,0,0.8); padding: 15px; display: flex; justify-content: center; gap: 15px; border-top: 1px solid #333; }
+    .controls { pointer-events: auto; background: rgba(0,0,0,0.8); padding: 15px; display: flex; justify-content: center; gap: 15px; border-top: 1px solid #333; flex-wrap: wrap; }
     button { background: #333; color: white; border: 1px solid #555; padding: 10px 20px; font-family: inherit; font-size: 16px; cursor: pointer; transition: 0.2s; }
     button:hover { background: #555; } button:active { transform: translateY(1px); }
     .btn-red { border-bottom: 3px solid #ff4d4d; } .btn-blue { border-bottom: 3px solid #4d4dff; } .btn-reset { border-bottom: 3px solid white; } .btn-copilot { border-bottom: 3px solid #10b981; }
+    .auto-decisions-toggle { display: inline-flex; align-items: center; gap: 8px; font-size: 14px; letter-spacing: 0.03em; text-transform: uppercase; }
+    .auto-decisions-toggle input { accent-color: #10b981; width: 16px; height: 16px; }
     .rvb-toast { pointer-events: none; position: absolute; top: 70px; right: 20px; max-width: 320px; background: rgba(15, 23, 42, 0.92); border: 1px solid rgba(148, 163, 184, 0.35); padding: 12px 14px; border-radius: 12px; font-size: 14px; line-height: 1.4; box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
     .rvb-toast strong { display: block; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: #10b981; margin-bottom: 6px; }
   `}</style>

--- a/src/frontend/src/redvsblue/config/ui.ts
+++ b/src/frontend/src/redvsblue/config/ui.ts
@@ -10,7 +10,7 @@ export type UIConfig = {
 }
 
 export const DEFAULT_UI_CONFIG: UIConfig = {
-  snapshotIntervalMs: 2_000,
+  snapshotIntervalMs: 30_000,
   toastTimeoutMs: 4_500,
   starsCount: 150,
   particleLifetimeMs: 33.33,


### PR DESCRIPTION
### Motivation
- Implement DES014 (Phase 3) to add a user-controlled auto-decisions flow and safe periodic snapshot cadence for the Red vs Blue AI Director.  
- Prevent runaway/unsafe decision requests by letting the user opt-in and enforcing server-side snapshot interval bounds.

### Description
- Add an Auto-decisions toggle in the RedVsBlue UI and track its state to gate snapshot decision requests (`src/frontend/src/redvsblue/RedVsBlue.tsx`, `src/frontend/src/redvsblue/RedVsBlueControls.tsx`).
- Only include `requestDecision` in snapshot payloads when the toggle is enabled, and wire toggle feedback via toast messaging (`RedVsBlue.tsx`).
- Add styling for the new control and ensure layout remains responsive (`src/frontend/src/redvsblue/RedVsBlueStyles.tsx`).
- Align defaults and safe bounds for snapshot cadence: frontend default set to 30s (`src/frontend/src/redvsblue/config/ui.ts`) and backend enforces clamp range min=5s / max=60s / default=30s (`src/backend/src/app.ts`).
- Document the Phase 3 plan and completion in the Memory Bank and update the task index (`memory/tasks/TASK016-redvsblue-ai-director-phase3-auto-decisions.md`, `memory/tasks/_index.md`).

### Testing
- Ran the frontend dev server with `pnpm -F @copilot-playground/frontend dev --host 0.0.0.0 --port 4173`, which started Vite but the dev build surfaced unresolved dependency errors (missing/optimized imports such as `zustand` and `@radix-ui/react-collapsible`) that prevented full runtime validation. (Observed dependency resolution errors in the Vite logs.)
- Captured an automated UI snapshot using Playwright; the screenshot artifact was produced successfully (`artifacts/redvsblue-auto-decisions.png`) which demonstrates the new control rendering in the app shell.  
- No unit/test suite was executed as part of this change; unresolved frontend dependency issues should be fixed before running the full test matrix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759f29b878832aaf9cf014b9bfea41)