### PR TITLE
Implement Copilot CLI Model Probe and Caching Mechanism

### DIFF
--- a/docs/library/copilot-sdk/README.md
+++ b/docs/library/copilot-sdk/README.md
@@ -34,6 +34,16 @@ They are written for the project layout in this repo:
 - The Copilot package uses a centralized default model accessor (`getDefaultModel`) located at `src/copilot/src/defaults.ts`. It returns the value of `COPILOT_DEFAULT_MODEL` or `gpt-5-mini` if unset. To change the runtime default, set the `COPILOT_DEFAULT_MODEL` env var or update the centralized default.
 - At runtime the Copilot service may map an abstract requested model to an actual provider model. The SDK listens for provider usage events and emits a `sdk.model.mismatch` **warning** when the requested model differs from the provider-reported model. The warning includes `requestedModel`, `actualModel`, and `providerCallId` to help with debugging and tracing.
 
+### `/models` endpoint (Copilot CLI advertised models)
+
+The Copilot service exposes a best-effort endpoint to discover which models the **local Copilot CLI** advertises in the current environment:
+
+- `GET /models` → returns `{ source, models, cached, ttlExpiresAt, error? }`
+- Caches results in-process (default TTL `60s`, configurable via `COPILOT_MODELS_TTL_SECONDS`)
+- Optional cache bypass: `GET /models?refresh=true`
+
+`source` is typically `cli` (parsed from the CLI), or `fallback` if the CLI is missing/unparseable.
+
 ## For *this* repo
 
 - Suggested 3-service architecture (frontend/backend/copilot) → [`09-playground-architecture.md`](./09-playground-architecture.md)

--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -14,6 +14,7 @@
 - 2026-01-25: Scoped monolith refactor candidates (backend `app.ts`, frontend `chat-playground.tsx`, RedVsBlue `useGame.ts`).
 - 2026-01-25: Split backend services, ChatPlayground presentational components, and RedVsBlue engine core/entities; added deterministic and parity tests (TASK019).
  - 2026-01-25: Added CI coverage thresholds + router thinness guard and documented post-refactor module layout (TASK020); tests/builds passed.
+- 2026-01-25: Added Copilot CLI model probing + `GET /models` endpoint with caching, metrics, and unit tests (TASK022).
 
 **Monolith inventory (2026-01-25):**
 - `src/backend/src/app.ts` (~36KB): API routes + decision validation + streaming fallback logic.

--- a/memory/designs/DES021-copilot-cli-model-probe.md
+++ b/memory/designs/DES021-copilot-cli-model-probe.md
@@ -1,7 +1,8 @@
 # DES021 — Copilot CLI Model Probe & /models Endpoint 📡
 
-**Status:** Proposed
+**Status:** Implemented ✅
 **Created:** 2026-01-25
+**Updated:** 2026-01-25
 
 ## Overview
 

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -3,6 +3,7 @@
 **What works:**
 - Frontend, backend, and copilot services run locally in development.
 - Milestone A–D implemented; Milestone E (workspace mount + secrets) implemented on 2026-01-24.
+- Copilot service exposes `GET /models` with cached Copilot CLI advertised models (TASK022, 2026-01-25).
 
 **What's left / Next:**
 - Complete Milestone F: switch to Copilot SDK (`TASK004`) and validate with integration tests.

--- a/memory/tasks/TASK022-cli-model-probe.md
+++ b/memory/tasks/TASK022-cli-model-probe.md
@@ -1,6 +1,6 @@
 # [TASK022] — Implement Copilot CLI Model Probe (/models endpoint)
 
-**Status:** Not Started  
+**Status:** Completed ✅  
 **Added:** 2026-01-25  
 **Updated:** 2026-01-25
 
@@ -70,6 +70,9 @@ Implement DES021: add a best-effort probe of the local `copilot` CLI to discover
 ### 2026-01-25
 
 - Created spec DES021 and task file TASK022. Planned implementation and test strategy.
+- Implemented CLI model probing + caching and exposed `GET /models` with `?refresh=true`.
+- Added unit tests for probe parsing/caching and HTTP handler behavior.
+- Documented `/models` in `docs/library/copilot-sdk/README.md` and `src/copilot/README.md`.
 
 ## Acceptance Criteria
 

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -21,3 +21,4 @@
 - TASK019 - Refactor: Monolithic files — Phase 2 (Break into modules & add tests) - Completed (2026-01-25)
 - TASK020 - Refactor: Monolithic files — Phase 3 (Cleanup, docs & CI guardrails) - Completed (2026-01-25)
 - TASK021 - Playwright E2E Coverage (Deferred from Phase 2) - Pending (2026-01-25)
+- TASK022 - Copilot CLI model probe (/models endpoint) - Completed ✅ (2026-01-25)

--- a/src/copilot/README.md
+++ b/src/copilot/README.md
@@ -183,6 +183,24 @@ Content-Type: application/json
 - **503 Service Unavailable**: Missing token configuration
 - **500 Internal Server Error**: Copilot CLI spawn failure
 
+### Model Discovery
+
+```bash
+GET /models
+GET /models?refresh=true
+```
+
+Response:
+
+```json
+{
+  "source": "cli",
+  "models": ["gpt-4o", "gpt-5-mini"],
+  "cached": false,
+  "ttlExpiresAt": "2026-01-25T00:00:00.000Z"
+}
+```
+
 ## Error Handling
 
 The service provides clear, actionable error messages:

--- a/src/copilot/src/cli-models-probe.ts
+++ b/src/copilot/src/cli-models-probe.ts
@@ -1,0 +1,465 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getCopilotCandidatePaths } from "./copilot-cli.js";
+import { incrementMetric } from "./metrics.js";
+import type { EventBus } from "@copilot-playground/shared";
+
+/**
+ * Result of probing the Copilot CLI for available models
+ */
+export interface ProbeResult {
+  source: "cli" | "fallback" | "error";
+  models: string[];
+  error?: string;
+}
+
+/**
+ * Cache entry for models probe results
+ */
+interface CacheEntry {
+  result: ProbeResult;
+  expiresAt: number;
+}
+
+// In-memory cache for probe results
+let cache: CacheEntry | null = null;
+
+/**
+ * Get the TTL for cache in seconds from environment variable
+ */
+function getCacheTTL(): number {
+  const ttlEnv = process.env.COPILOT_MODELS_TTL_SECONDS;
+  if (ttlEnv) {
+    const ttl = parseInt(ttlEnv, 10);
+    if (!isNaN(ttl) && ttl > 0) {
+      return ttl;
+    }
+  }
+  return 60; // default 60 seconds
+}
+
+/**
+ * Normalize and deduplicate model IDs
+ */
+function normalizeModels(models: string[]): string[] {
+  return Array.from(new Set(
+    models
+      .map((m) => m.trim())
+      .filter((m) => m.length > 0)
+      .map((m) => m.replace(/[(),]/g, "").trim())
+  )).sort();
+}
+
+/**
+ * Parse models from "Allowed choices are ..." error message
+ */
+function parseAllowedChoices(stderr: string): string[] {
+  const regex = /Allowed choices are\s*:?\s*(.*)/i;
+  const match = stderr.match(regex);
+  
+  if (match && match[1]) {
+    // Split by comma and clean up
+    return normalizeModels(match[1].split(","));
+  }
+  
+  return [];
+}
+
+/**
+ * Try to parse JSON output from copilot --model list --json
+ */
+function parseJsonOutput(stdout: string): string[] {
+  try {
+    const parsed = JSON.parse(stdout);
+    
+    // Handle different JSON structures
+    if (Array.isArray(parsed)) {
+      return normalizeModels(parsed);
+    } else if (parsed.models && Array.isArray(parsed.models)) {
+      return normalizeModels(parsed.models);
+    } else if (parsed.list && Array.isArray(parsed.list)) {
+      return normalizeModels(parsed.list);
+    }
+  } catch (e) {
+    // Not valid JSON, will fall back to other methods
+  }
+  
+  return [];
+}
+
+/**
+ * Try to extract models from copilot --help output
+ */
+function parseHelpOutput(output: string): string[] {
+  // Look for lines that might contain model lists
+  const lines = output.split("\n");
+  const modelLines = lines.filter((line) => 
+    line.includes("model") || 
+    line.includes("gpt") || 
+    line.includes("claude") ||
+    line.includes("anthropic")
+  );
+  
+  // Try to extract model names using common patterns
+  const modelPattern = /(?:gpt|claude|anthropic)-[a-z0-9][a-z0-9.-]*/gi;
+  const matches: string[] = [];
+  
+  for (const line of modelLines) {
+    const lineMatches = line.match(modelPattern);
+    if (lineMatches) {
+      matches.push(...lineMatches);
+    }
+  }
+  
+  return normalizeModels(matches);
+}
+
+/**
+ * Get fallback models from package.json or return a curated list
+ */
+function getFallbackModels(): string[] {
+  // Try to read from the installed @github/copilot package (best-effort).
+  try {
+    const fileDir = path.dirname(fileURLToPath(import.meta.url));
+    const packageRoot = path.resolve(fileDir, "..", ".."); // src/copilot
+    const copilotPkgRoot = path.join(packageRoot, "node_modules", "@github", "copilot");
+    const packageJsonPath = path.join(copilotPkgRoot, "package.json");
+    const readmePath = path.join(copilotPkgRoot, "README.md");
+    
+    const haystacks: string[] = [];
+
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as { description?: string };
+      if (packageJson.description) haystacks.push(packageJson.description);
+    }
+
+    if (fs.existsSync(readmePath)) {
+      haystacks.push(fs.readFileSync(readmePath, "utf-8"));
+    }
+
+    const modelPattern = /(?:gpt|claude|anthropic)-[a-z0-9][a-z0-9.-]*/gi;
+    const matches = haystacks.flatMap((t) => t.match(modelPattern) ?? []);
+    if (matches.length > 0) return normalizeModels(matches);
+  } catch (e) {
+    // Fall through to curated list
+  }
+  
+  // Curated fallback list of common models
+  return normalizeModels([
+    "gpt-4o",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "claude-3-opus",
+    "claude-3-sonnet",
+    "claude-3-haiku",
+  ]);
+}
+
+/**
+ * Spawn a command with timeout and output limits
+ */
+async function spawnWithTimeout(
+  cmd: string,
+  args: string[],
+  timeoutMs: number = 5000,
+  maxOutputSize: number = 1024 * 1024 // 1MB
+): Promise<{ success: boolean; stdout: string; stderr: string; error?: Error | null }> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    
+    const child = spawn(cmd, args, {
+      env: {
+        ...process.env,
+        GH_TOKEN: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+      },
+    });
+    
+    // Set timeout
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      resolve({ 
+        success: false, 
+        stdout: "", 
+        stderr: "Command timed out",
+        error: new Error(`Command timed out after ${timeoutMs}ms`)
+      });
+    }, timeoutMs);
+    
+    if (child.stdout) {
+      child.stdout.on("data", (chunk: Buffer) => {
+        const chunkStr = chunk.toString();
+        // Limit output size to prevent memory issues
+        if (stdout.length + chunkStr.length <= maxOutputSize) {
+          stdout += chunkStr;
+        }
+      });
+    }
+    
+    if (child.stderr) {
+      child.stderr.on("data", (chunk: Buffer) => {
+        const chunkStr = chunk.toString();
+        if (stderr.length + chunkStr.length <= maxOutputSize) {
+          stderr += chunkStr;
+        }
+      });
+    }
+    
+    child.on("error", (error: Error & { code?: string }) => {
+      clearTimeout(timeout);
+      resolve({ success: false, stdout, stderr, error });
+    });
+    
+    child.on("close", (code: number) => {
+      clearTimeout(timeout);
+      if (!timedOut) {
+        if (code === 0) {
+          resolve({ success: true, stdout, stderr, error: null });
+        } else {
+          resolve({ success: false, stdout, stderr, error: new Error(`Process exited with code ${code}`) });
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Probe the Copilot CLI for available models
+ */
+export async function probeCliModels(eventBus?: EventBus): Promise<ProbeResult> {
+  incrementMetric("model_probe_count");
+  
+  if (eventBus) {
+    eventBus.emitLog({
+      timestamp: new Date().toISOString(),
+      level: "debug",
+      component: "copilot",
+      event_type: "cli.models.probe.start",
+      message: "Starting Copilot CLI model probe",
+    });
+  }
+  
+  // Try different strategies in order
+  const strategies = [
+    { name: "json", cmd: "copilot", args: ["--model", "list", "--json"] },
+    { name: "invalid", cmd: "copilot", args: ["--model", "INVALID_PROBE"] },
+    { name: "help", cmd: "copilot", args: ["--help"] },
+  ];
+
+  let lastErrorMessage: string | undefined;
+  
+  for (const strategy of strategies) {
+    // Try candidate paths first
+    const candidatePaths = getCopilotCandidatePaths();
+    const candidatesToTry = [strategy.cmd, ...candidatePaths.filter(p => p !== strategy.cmd)];
+    
+    for (const cmdToTry of candidatesToTry) {
+      try {
+        const result = await spawnWithTimeout(cmdToTry, strategy.args);
+        
+        if (result.success) {
+          // JSON strategy succeeded
+          if (strategy.name === "json") {
+            const models = parseJsonOutput(result.stdout);
+            if (models.length > 0) {
+              const probeResult: ProbeResult = {
+                source: "cli",
+                models,
+              };
+              
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "debug",
+                  component: "copilot",
+                  event_type: "cli.models.probe.parsed",
+                  message: "Parsed models from JSON output",
+                  meta: { models, count: models.length },
+                });
+              }
+
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "info",
+                  component: "copilot",
+                  event_type: "cli.models.probe.success",
+                  message: "Copilot CLI model probe succeeded (json)",
+                  meta: { count: models.length },
+                });
+              }
+              
+              return probeResult;
+            }
+          } else if (strategy.name === "help") {
+            // Help strategy - try to extract models
+            const models = parseHelpOutput(result.stdout);
+            if (models.length > 0) {
+              const probeResult: ProbeResult = {
+                source: "cli",
+                models,
+              };
+              
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "debug",
+                  component: "copilot",
+                  event_type: "cli.models.probe.parsed",
+                  message: "Parsed models from help output",
+                  meta: { models, count: models.length },
+                });
+              }
+
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "info",
+                  component: "copilot",
+                  event_type: "cli.models.probe.success",
+                  message: "Copilot CLI model probe succeeded (help)",
+                  meta: { count: models.length },
+                });
+              }
+              
+              return probeResult;
+            }
+          }
+        } else {
+          if (result.error) {
+            lastErrorMessage = result.error.message;
+          } else if (result.stderr.trim().length > 0) {
+            lastErrorMessage = result.stderr.trim().slice(0, 200);
+          }
+
+          // Invalid model strategy - parse error message
+          if (strategy.name === "invalid") {
+            const models = parseAllowedChoices(result.stderr);
+            if (models.length > 0) {
+              const probeResult: ProbeResult = {
+                source: "cli",
+                models,
+              };
+              
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "debug",
+                  component: "copilot",
+                  event_type: "cli.models.probe.parsed",
+                  message: "Parsed models from allowed choices error",
+                  meta: { models, count: models.length },
+                });
+              }
+
+              if (eventBus) {
+                eventBus.emitLog({
+                  timestamp: new Date().toISOString(),
+                  level: "info",
+                  component: "copilot",
+                  event_type: "cli.models.probe.success",
+                  message: "Copilot CLI model probe succeeded (allowed choices)",
+                  meta: { count: models.length },
+                });
+              }
+              
+              return probeResult;
+            }
+          }
+        }
+      } catch (error) {
+        const err = error as (Error & { code?: string }) | unknown;
+        const errCode = typeof err === "object" && err && "code" in err ? (err as { code?: string }).code : undefined;
+        const errMessage = err instanceof Error ? err.message : String(err);
+
+        lastErrorMessage = errMessage;
+
+        // Expected operational errors: continue and fall back if needed.
+        if (errCode === "ENOENT" || errCode === "ETIMEDOUT") {
+          continue;
+        }
+
+        // Unexpected internal errors should surface to the caller.
+        throw error;
+      }
+    }
+  }
+  
+  // If we get here, all strategies failed - return fallback
+  incrementMetric("model_probe_failure_count");
+  const fallbackModels = getFallbackModels();
+  
+  if (eventBus) {
+    eventBus.emitLog({
+      timestamp: new Date().toISOString(),
+      level: "warn",
+      component: "copilot",
+      event_type: "cli.models.probe.error",
+      message: "Copilot CLI model probe failed; using fallback model list",
+      meta: { count: fallbackModels.length, error: lastErrorMessage },
+    });
+  }
+  
+  return {
+    source: "fallback",
+    models: fallbackModels,
+    error: lastErrorMessage,
+  };
+}
+
+/**
+ * Get cached models or probe if cache is expired
+ */
+export async function getCachedModels(eventBus?: EventBus, refresh: boolean = false): Promise<ProbeResult & { cached: boolean; ttlExpiresAt?: string }> {
+  const now = Date.now();
+  const ttlSeconds = getCacheTTL();
+  const ttlMs = ttlSeconds * 1000;
+  
+  // Force refresh if requested
+  if (refresh) {
+    const result = await probeCliModels(eventBus);
+    cache = {
+      result,
+      expiresAt: now + ttlMs,
+    };
+    
+    return {
+      ...result,
+      cached: false,
+      ttlExpiresAt: new Date(cache.expiresAt).toISOString(),
+    };
+  }
+  
+  // Use cache if available and not expired
+  if (cache && now < cache.expiresAt) {
+    return {
+      ...cache.result,
+      cached: true,
+      ttlExpiresAt: new Date(cache.expiresAt).toISOString(),
+    };
+  }
+  
+  // Probe and cache the result
+  const result = await probeCliModels(eventBus);
+  cache = {
+    result,
+    expiresAt: now + ttlMs,
+  };
+  
+  return {
+    ...result,
+    cached: false,
+    ttlExpiresAt: new Date(cache.expiresAt).toISOString(),
+  };
+}
+
+/**
+ * Clear the models cache (useful for testing)
+ */
+export function clearModelsCache(): void {
+  cache = null;
+}

--- a/tests/copilot/unit/cli-models-probe.test.ts
+++ b/tests/copilot/unit/cli-models-probe.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { probeCliModels, getCachedModels, clearModelsCache } from "../../../src/copilot/src/cli-models-probe.js";
+import { getMetric, resetMetrics } from "../../../src/copilot/src/metrics.js";
+import { createEventBus } from "../../../src/shared/src/index.js";
+
+// Mock child_process spawn
+vi.mock("node:child_process", () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
+
+describe("CLI Models Probe", () => {
+  const originalEnv = process.env;
+  const eventBus = createEventBus();
+
+  beforeEach(() => {
+    // Reset env and metrics before each test
+    process.env = { ...originalEnv };
+    resetMetrics();
+    clearModelsCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore original env
+    process.env = originalEnv;
+  });
+
+  describe("probeCliModels", () => {
+    it("should parse models from JSON output when available", async () => {
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4", "gpt-3-5-turbo"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      const result = await probeCliModels();
+      
+      expect(result.source).toBe("cli");
+      expect(result.models).toContain("gpt-4");
+      expect(result.models).toContain("gpt-3-5-turbo");
+      expect(result.models.length).toBe(2);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should parse models from allowed choices error message", async () => {
+      // Mock spawn to return error with allowed choices
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from("Error: Invalid model. Allowed choices are: gpt-4, gpt-3-5-turbo, claude-3-opus"));
+            }
+          }),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(1);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      const result = await probeCliModels();
+      
+      expect(result.source).toBe("cli");
+      expect(result.models).toContain("gpt-4");
+      expect(result.models).toContain("gpt-3-5-turbo");
+      expect(result.models).toContain("claude-3-opus");
+      expect(result.models.length).toBe(3);
+    });
+
+    it("should return fallback models when CLI is not available", async () => {
+      // Mock spawn to throw ENOENT error
+      const mockSpawn = vi.mocked(spawn);
+      mockSpawn.mockImplementation(() => {
+        const error = new Error("spawn ENOENT");
+        (error as any).code = "ENOENT";
+        throw error;
+      });
+
+      const result = await probeCliModels();
+      
+      expect(result.source).toBe("fallback");
+      expect(result.models.length).toBeGreaterThan(0);
+      expect(result.models).toContain("gpt-4");
+      expect(result.models).toContain("claude-3-opus");
+    });
+
+    it("should handle timeout gracefully", async () => {
+      // Mock spawn to throw timeout error
+      const mockSpawn = vi.mocked(spawn);
+      mockSpawn.mockImplementation(() => {
+        const error = new Error("Command timed out");
+        (error as any).code = "ETIMEDOUT";
+        throw error;
+      });
+
+      const result = await probeCliModels();
+      
+      // Should fall back to fallback models
+      expect(result.source).toBe("fallback");
+      expect(result.models.length).toBeGreaterThan(0);
+    });
+
+    it("should increment metrics on probe attempt", async () => {
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      // Reset metrics before test
+      resetMetrics();
+
+      await probeCliModels();
+      
+      // Check that metrics were incremented
+      const probeCount = getMetric("model_probe_count");
+      expect(probeCount).toBe(1);
+    });
+
+    it("should emit logs when eventBus is provided", async () => {
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      // Spy on eventBus emitLog
+      const emitLogSpy = vi.spyOn(eventBus, "emitLog");
+
+      await probeCliModels(eventBus);
+      
+      expect(emitLogSpy).toHaveBeenCalledWith(expect.objectContaining({
+        event_type: "cli.models.probe.start",
+      }));
+      expect(emitLogSpy).toHaveBeenCalledWith(expect.objectContaining({
+        event_type: "cli.models.probe.parsed",
+      }));
+    });
+  });
+
+  describe("getCachedModels", () => {
+    it("should return cached result when cache is valid", async () => {
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      // First call - should probe
+      const firstResult = await getCachedModels();
+      expect(firstResult.cached).toBe(false);
+      expect(firstResult.models).toContain("gpt-4");
+
+      // Second call - should use cache
+      const secondResult = await getCachedModels();
+      expect(secondResult.cached).toBe(true);
+      expect(secondResult.models).toContain("gpt-4");
+    });
+
+    it("should respect refresh flag and force re-probe", async () => {
+      // Mock spawn to return different results
+      const mockSpawn = vi.mocked(spawn);
+      let callCount = 0;
+      
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              if (callCount === 0) {
+                callback(Buffer.from('{"models": ["gpt-4"]}'));
+              } else {
+                callback(Buffer.from('{"models": ["gpt-4", "gpt-3.5-turbo"]}'));
+              }
+              callCount++;
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      // First call
+      const firstResult = await getCachedModels();
+      expect(firstResult.cached).toBe(false);
+      expect(firstResult.models.length).toBe(1);
+
+      // Second call with refresh=true - should re-probe
+      const secondResult = await getCachedModels(undefined, true);
+      expect(secondResult.cached).toBe(false);
+      expect(secondResult.models.length).toBe(2);
+    });
+
+    it("should respect COPILOT_MODELS_TTL_SECONDS environment variable", async () => {
+      // Set custom TTL
+      process.env.COPILOT_MODELS_TTL_SECONDS = "1"; // 1 second
+
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      // First call
+      const firstResult = await getCachedModels();
+      expect(firstResult.cached).toBe(false);
+
+      // Wait for cache to expire
+      await new Promise(resolve => setTimeout(resolve, 1100));
+
+      // Second call - should re-probe due to expired cache
+      const secondResult = await getCachedModels();
+      expect(secondResult.cached).toBe(false);
+    });
+
+    it("should include ttlExpiresAt in response", async () => {
+      // Mock spawn to return JSON output
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      const result = await getCachedModels();
+      
+      expect(result.ttlExpiresAt).toBeDefined();
+      expect(new Date(result.ttlExpiresAt).getTime()).toBeGreaterThan(Date.now());
+    });
+  });
+
+  describe("normalization and deduplication", () => {
+    it("should normalize and deduplicate model IDs", async () => {
+      // Mock spawn to return messy data
+      const mockSpawn = vi.mocked(spawn);
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(Buffer.from('{"models": ["  gpt-4  ", "gpt-4", "(gpt-3-5-turbo)"]}'));
+            }
+          }),
+        },
+        stderr: {
+          on: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+      
+      mockSpawn.mockReturnValue(mockChild as any);
+
+      const result = await probeCliModels();
+      
+      // Check that models are normalized and deduplicated
+      expect(result.models).toContain("gpt-4");
+      expect(result.models).toContain("gpt-3-5-turbo");
+      expect(result.models.length).toBe(2); // Should be deduplicated
+    });
+  });
+});

--- a/tests/copilot/unit/http-models.test.ts
+++ b/tests/copilot/unit/http-models.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { createApp } from "../../../src/copilot/src/index.js";
+import { resetMetrics } from "../../../src/copilot/src/metrics.js";
+import type { AddressInfo } from "node:net";
+
+// Mock child_process spawn
+vi.mock("node:child_process", () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
+
+describe("/models endpoint", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset env and metrics before each test
+    process.env = { ...originalEnv };
+    resetMetrics();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore original env
+    process.env = originalEnv;
+  });
+
+  it("should return models from probe with cache info", async () => {
+    // Mock spawn to return JSON output
+    const mockSpawn = vi.mocked(spawn);
+    const mockChild = {
+      stdout: {
+        on: vi.fn((event, callback) => {
+          if (event === "data") {
+            callback(Buffer.from('{"models": ["gpt-4", "gpt-3-5-turbo"]}'));
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn((event, callback) => {
+        if (event === "close") {
+          callback(0);
+        }
+      }),
+    };
+    
+    mockSpawn.mockReturnValue(mockChild as any);
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    const res = await fetch(`${url}/models`);
+    const json = await res.json();
+
+    server.close();
+
+    expect(res.ok).toBe(true);
+    expect(json.source).toBe("cli");
+    expect(json.models).toContain("gpt-4");
+    expect(json.models).toContain("gpt-3-5-turbo");
+    expect(json.cached).toBe(false);
+    expect(json.ttlExpiresAt).toBeDefined();
+    expect(json.error).toBeUndefined();
+  });
+
+  it("should return cached result on second call", async () => {
+    // Mock spawn to return JSON output
+    const mockSpawn = vi.mocked(spawn);
+    const mockChild = {
+      stdout: {
+        on: vi.fn((event, callback) => {
+          if (event === "data") {
+            callback(Buffer.from('{"models": ["gpt-4"]}'));
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn((event, callback) => {
+        if (event === "close") {
+          callback(0);
+        }
+      }),
+    };
+    
+    mockSpawn.mockReturnValue(mockChild as any);
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    // First call
+    const res1 = await fetch(`${url}/models`);
+    const json1 = await res1.json();
+
+    // Second call - should be cached
+    const res2 = await fetch(`${url}/models`);
+    const json2 = await res2.json();
+
+    server.close();
+
+    expect(json1.cached).toBe(false);
+    expect(json2.cached).toBe(true);
+  });
+
+  it("should respect refresh=true query parameter", async () => {
+    // Mock spawn to return different results
+    const mockSpawn = vi.mocked(spawn);
+    let callCount = 0;
+    
+    const mockChild = {
+      stdout: {
+        on: vi.fn((event, callback) => {
+          if (event === "data") {
+            if (callCount === 0) {
+              callback(Buffer.from('{"models": ["gpt-4"]}'));
+            } else {
+              callback(Buffer.from('{"models": ["gpt-4", "gpt-3.5-turbo"]}'));
+            }
+            callCount++;
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn((event, callback) => {
+        if (event === "close") {
+          callback(0);
+        }
+      }),
+    };
+    
+    mockSpawn.mockReturnValue(mockChild as any);
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    // First call
+    const res1 = await fetch(`${url}/models`);
+    const json1 = await res1.json();
+
+    // Second call with refresh=true
+    const res2 = await fetch(`${url}/models?refresh=true`);
+    const json2 = await res2.json();
+
+    server.close();
+
+    expect(json1.cached).toBe(false);
+    expect(json1.models.length).toBe(1);
+    expect(json2.cached).toBe(false);
+    expect(json2.models.length).toBe(2);
+  });
+
+  it("should return fallback models when CLI probe fails", async () => {
+    // Mock spawn to throw error
+    const mockSpawn = vi.mocked(spawn);
+    mockSpawn.mockImplementation(() => {
+      const error = new Error("spawn ENOENT");
+      (error as any).code = "ENOENT";
+      throw error;
+    });
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    const res = await fetch(`${url}/models`);
+    const json = await res.json();
+
+    server.close();
+
+    expect(res.ok).toBe(true);
+    expect(json.source).toBe("fallback");
+    expect(json.models.length).toBeGreaterThan(0);
+    expect(json.cached).toBe(false);
+  });
+
+  it("should return 500 and error details when probe throws exception", async () => {
+    // Mock spawn to throw unexpected error
+    const mockSpawn = vi.mocked(spawn);
+    mockSpawn.mockImplementation(() => {
+      throw new Error("Unexpected error");
+    });
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    const res = await fetch(`${url}/models`);
+    const json = await res.json();
+
+    server.close();
+
+    expect(res.status).toBe(500);
+    expect(json.source).toBe("error");
+    expect(json.models.length).toBe(0);
+    expect(json.error).toContain("Unexpected error");
+  });
+
+  it("should include model probe metrics in /metrics endpoint", async () => {
+    // Mock spawn to return JSON output
+    const mockSpawn = vi.mocked(spawn);
+    const mockChild = {
+      stdout: {
+        on: vi.fn((event, callback) => {
+          if (event === "data") {
+            callback(Buffer.from('{"models": ["gpt-4"]}'));
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0);
+          }
+        }),
+      };
+    
+    mockSpawn.mockReturnValue(mockChild as any);
+
+    const app = createApp();
+    const server = app.listen(0);
+
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}`;
+
+    // Call /models to trigger probe
+    await fetch(`${url}/models`);
+
+    // Check /metrics
+    const res = await fetch(`${url}/metrics`);
+    const text = await res.text();
+
+    server.close();
+
+    expect(text).toMatch(/# HELP copilot_model_probe_total/);
+    expect(text).toMatch(/copilot_model_probe_total \d+/); // Check that it's a number
+  });
+});


### PR DESCRIPTION
Introduce a new endpoint `GET /models` to probe and cache available models from the local Copilot CLI. This implementation includes unit tests and metrics for monitoring probe attempts and failures. Update documentation to reflect the new functionality.