### PR TITLE
Refactor backend and frontend for improved modularity and testability

### DIFF
--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -1,6 +1,7 @@
 # Active Context
 
 **Current focus:**
+
 - Finalize Milestone E: Workspace mount + secrets (completed 2026-01-24).  
 - Continue Milestone F: switch to Copilot SDK (`TASK004`) — in progress.  
 - Continue Milestone C: end-to-end streaming tests and integration (`TASK006`) — in progress.
@@ -10,18 +11,22 @@
 - Defer Playwright E2E coverage to `TASK021` (pending).
 
 **Recent changes:**
+
 - 2026-01-23/24: Implemented workspace read-only mount, `WORKDIR /workspace`, Compose wiring, and dotenvx secrets-first documentation (see commits in repository history).
 - 2026-01-25: Scoped monolith refactor candidates (backend `app.ts`, frontend `chat-playground.tsx`, RedVsBlue `useGame.ts`).
 - 2026-01-25: Split backend services, ChatPlayground presentational components, and RedVsBlue engine core/entities; added deterministic and parity tests (TASK019).
- - 2026-01-25: Added CI coverage thresholds + router thinness guard and documented post-refactor module layout (TASK020); tests/builds passed.
+- 2026-01-25: Added CI coverage thresholds + router thinness guard and documented post-refactor module layout (TASK020); tests/builds passed.
 - 2026-01-25: Added Copilot CLI model probing + `GET /models` endpoint with caching, metrics, and unit tests (TASK022).
+- 2026-01-26: Extracted RedVsBlue `useGame` responsibilities into engine/renderer/telemetry/fps managers with unit coverage (TASK026).
 
-**Monolith inventory (2026-01-25):**
+**Monolith inventory (2026-01-26):**
+
 - `src/backend/src/app.ts` (~36KB): API routes + decision validation + streaming fallback logic.
 - `src/frontend/src/components/chat-playground.tsx` (~25KB): chat UI + streaming + backend probe.
-- `src/frontend/src/redvsblue/useGame.ts` (~13KB): engine lifecycle + canvas sizing + telemetry wiring.
+- `src/frontend/src/redvsblue/useGame.ts` (~8KB): orchestration layer after manager extraction.
 
 **Next steps:**
+
 1. Add a small follow-up to codify secrets guidance and add automated checks (create `DES009` and `TASK009`).
 2. Finish SDK migration work (complete `TASK004`) and add integration tests that exercise SDK mode in CI.
 3. Add automated integration tests for workspace mount visibility and dotenvx key handling.
@@ -30,5 +35,6 @@
 6. Plan next CI validation work for guardrails (coverage + router) in a PR.
 
 **Active decisions:**
+
 - Default to read-only workspace mounts and document opt-in for read/write in a future milestone.
 - Follow a secrets-first pattern: provide decryption keys at runtime and avoid baking keys into images.

--- a/memory/designs/DES025-useGame-extraction.md
+++ b/memory/designs/DES025-useGame-extraction.md
@@ -1,6 +1,6 @@
 # DES025 - Frontend: Extract engine & renderer responsibilities from `useGame`
 
-**Status:** Proposed
+**Status:** Implemented
 **Related tasks:** TASK026
 **Related issues:** #83
 
@@ -36,4 +36,4 @@
 
 ---
 
-*Created: 2026-01-26*
+Created: 2026-01-26

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -1,13 +1,16 @@
 # Progress
 
 **What works:**
+
 - Frontend, backend, and copilot services run locally in development.
 - Milestone A–D implemented; Milestone E (workspace mount + secrets) implemented on 2026-01-24.
 - Copilot service exposes `GET /models` with cached Copilot CLI advertised models (TASK022, 2026-01-25).
 - RedVsBlue match-store helpers are now split into focused modules with unit coverage (TASK024, 2026-01-26).
+- `useGame` responsibilities extracted into engine/renderer/telemetry/fps managers with tests (TASK026, 2026-01-26).
 - Full workspace test suite (`pnpm test`) passes after TASK024 updates (2026-01-26).
 
 **What's left / Next:**
+
 - Complete Milestone F: switch to Copilot SDK (`TASK004`) and validate with integration tests.
 - Add automated tests for secrets handling and Compose startup (`TASK009`).
 - Add CI validation steps for SDK and Compose integration.
@@ -16,6 +19,7 @@
 - Plan Playwright E2E implementation (`TASK021`) when ready.
 
 **Known issues:**
+
 - Read/write workspace mounts are deferred and require explicit opt-in.
 - CI coverage for Compose startup and secret handling is not yet implemented.
 

--- a/memory/tasks/TASK026-extract-useGame.md
+++ b/memory/tasks/TASK026-extract-useGame.md
@@ -1,34 +1,44 @@
 # TASK026 - Extract engine & renderer responsibilities from `useGame`
 
-**Status:** Pending
+**Status:** Completed
 **Added:** 2026-01-26
 **Updated:** 2026-01-26
 **Related issue:** #83
 
 ## Original Request
+
 Decompose `useGame.ts` to move engine lifecycle, worker wrapper logic, renderer/offscreen transfer, resize handling, FPS and telemetry logic into smaller, testable modules.
 
 ## Thought Process
+
 `useGame` mixes many concerns that are easier to unit test in isolation. An incremental extraction reduces risk: extract engine manager first (worker vs non-worker semantics), then renderer manager, then telemetry/fps helpers, and finally simplify the hook.
 
 ## Implementation Plan
+
 - Add `engineManager.ts` and unit tests for worker/non-worker flows.
 - Add `rendererManager.ts` with offscreen transfer and tests for failure/success paths.
 - Add `telemetryForwarder.ts` and `useFps.ts` and test timing behavior.
 - Simplify `useGame` to orchestrate those pieces and add integration tests.
 
+
 ### Subtasks
-| ID  | Description                     | Status      | Updated      | Notes |
-| --- | ------------------------------- | ----------- | ------------ | ----- |
-| 26.1 | Add `engineManager.ts`          | Not Started | 2026-01-26   |      |
-| 26.2 | Add `rendererManager.ts`        | Not Started | 2026-01-26   |      |
-| 26.3 | Add `telemetryForwarder.ts`     | Not Started | 2026-01-26   |      |
-| 26.4 | Add `useFps.ts`                 | Not Started | 2026-01-26   |      |
-| 26.5 | Simplify `useGame` and tests    | Not Started | 2026-01-26   |      |
+
+|ID|Description|Status|Updated|Notes|
+|---|---|---|---|---|
+|26.1|Add `engineManager.ts`|Completed|2026-01-26|Added unit tests.|
+|26.2|Add `rendererManager.ts`|Completed|2026-01-26|Added offscreen/resize tests.|
+|26.3|Add `telemetryForwarder.ts`|Completed|2026-01-26|Added gating/error tests.|
+|26.4|Add `useFps.ts`|Completed|2026-01-26|Hook + harness tests.|
+|26.5|Simplify `useGame` and tests|Completed|2026-01-26|Hook now orchestrates managers.|
 
 ## Progress Log
+
 ### 2026-01-26
+
 - Task created and design file DES025 added.
+- Added `engineManager`, `rendererManager`, `telemetryForwarder`, and `useFps` modules with unit coverage.
+- Refactored `useGame` into a coordinator using the new managers.
+- Ran frontend vitest suite (all tests passed; existing skips unchanged).
 
 
 ---

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -25,5 +25,5 @@
 - TASK023 - Shared RedVsBlue config (DES022) - Completed ✅ (2026-01-25)
 - TASK024 - RedVsBlue match store split - Completed ✅ (2026-01-26)
 - TASK025 - Refactor backend: split `app.ts` into routes/controllers/schemas/logging - Completed ✅ (2026-01-26)
-- TASK026 - Extract engine & renderer responsibilities from `useGame` - Pending (2026-01-26)
+- TASK026 - Extract engine & renderer responsibilities from `useGame` - Completed ✅ (2026-01-26)
 - TASK027 - Decompose `RedVsBlue.tsx` into match/session, AI director, and toast hooks - Pending (2026-01-26)

--- a/src/frontend/src/redvsblue/engineManager.ts
+++ b/src/frontend/src/redvsblue/engineManager.ts
@@ -1,0 +1,144 @@
+import type { EngineConfig, GameState, Team } from "@/redvsblue/types"
+import type { Engine as EngineAPI } from "@/redvsblue/types"
+
+import { createEngine } from "@/redvsblue/engine"
+import { EngineWorkerWrapper, type EngineWorkerWrapperOptions } from "@/redvsblue/worker/engineWorkerWrapper"
+
+export type WorkerCanvasControls = {
+  start: () => void
+  stop: () => void
+  setCanvas: (canvas: OffscreenCanvas, width: number, height: number) => void
+  resizeCanvas: (width: number, height: number) => void
+}
+
+export type EngineWithWorkerControls = EngineAPI & Partial<WorkerCanvasControls>
+
+export type EngineRef = {
+  current: EngineWithWorkerControls | null
+}
+
+export type EngineManagerOptions = {
+  engineRef: EngineRef
+  worker: boolean
+  workerTickHz?: number
+  workerSnapshotHz?: number
+  engineFactory?: () => EngineAPI
+  workerFactory?: (options: EngineWorkerWrapperOptions) => EngineWorkerWrapper
+}
+
+export type EngineManager = {
+  getEngine: () => EngineWithWorkerControls | null
+  ensureEngine: () => EngineWithWorkerControls
+  initEngine: (config: EngineConfig) => void
+  updateEngine: (dtMs: number, onSnapshot?: (snapshot: GameState) => void) => void
+  resetEngine: (onSnapshot?: (snapshot: GameState) => void) => void
+  spawnShip: (team: Team, overrides?: Partial<{ shipSpeed: number; bulletSpeed: number; bulletDamage: number; shipMaxHealth: number }>, onSnapshot?: (snapshot: GameState) => void) => void
+  startIfWorker: () => void
+  stopIfWorker: () => void
+  onWorkerSnapshot: (handler: (snapshot: GameState) => void) => () => void
+  destroyEngine: () => void
+}
+
+type Startable = { start: () => void }
+type Stoppable = { stop: () => void }
+
+const hasStart = (engine: EngineWithWorkerControls | null): engine is EngineWithWorkerControls & Startable => {
+  return !!engine && typeof (engine as Startable).start === "function"
+}
+
+const hasStop = (engine: EngineWithWorkerControls | null): engine is EngineWithWorkerControls & Stoppable => {
+  return !!engine && typeof (engine as Stoppable).stop === "function"
+}
+
+export function createEngineManager(options: EngineManagerOptions): EngineManager {
+  const {
+    engineRef,
+    worker,
+    workerTickHz,
+    workerSnapshotHz,
+    engineFactory = createEngine,
+    workerFactory = (opts) => new EngineWorkerWrapper(opts),
+  } = options
+
+  const getEngine = (): EngineWithWorkerControls | null => engineRef.current
+
+  const ensureEngine = (): EngineWithWorkerControls => {
+    if (engineRef.current) return engineRef.current
+    const engine = worker
+      ? workerFactory({ tickHz: workerTickHz, snapshotHz: workerSnapshotHz })
+      : engineFactory()
+    engineRef.current = engine as EngineWithWorkerControls
+    return engineRef.current
+  }
+
+  const initEngine = (config: EngineConfig): void => {
+    const engine = ensureEngine()
+    engine.init(config)
+  }
+
+  const updateEngine = (dtMs: number, onSnapshot?: (snapshot: GameState) => void): void => {
+    if (worker) return
+    const engine = engineRef.current
+    if (!engine) return
+    engine.update(dtMs)
+    if (onSnapshot) onSnapshot(engine.getState())
+  }
+
+  const resetEngine = (onSnapshot?: (snapshot: GameState) => void): void => {
+    const engine = engineRef.current
+    if (!engine) return
+    engine.reset()
+    if (!worker && onSnapshot) onSnapshot(engine.getState())
+  }
+
+  const spawnShip = (
+    team: Team,
+    overrides?: Partial<{ shipSpeed: number; bulletSpeed: number; bulletDamage: number; shipMaxHealth: number }>,
+    onSnapshot?: (snapshot: GameState) => void
+  ): void => {
+    const engine = engineRef.current
+    if (!engine) return
+    engine.spawnShip(team, overrides)
+    if (!worker && onSnapshot) onSnapshot(engine.getState())
+  }
+
+  const startIfWorker = (): void => {
+    if (!worker) return
+    if (hasStart(engineRef.current)) engineRef.current.start()
+  }
+
+  const stopIfWorker = (): void => {
+    if (!worker) return
+    if (hasStop(engineRef.current)) engineRef.current.stop()
+  }
+
+  const onWorkerSnapshot = (handler: (snapshot: GameState) => void): (() => void) => {
+    if (!worker) return () => {}
+    const engine = ensureEngine()
+    const wrapped = (data: unknown) => {
+      handler(data as GameState)
+    }
+    engine.on("snapshot", wrapped)
+    return () => engine.off("snapshot", wrapped)
+  }
+
+  const destroyEngine = (): void => {
+    const engine = engineRef.current
+    if (!engine) return
+    engine.destroy()
+    engineRef.current = null
+  }
+
+  return {
+    getEngine,
+    ensureEngine,
+    initEngine,
+    updateEngine,
+    resetEngine,
+    spawnShip,
+    startIfWorker,
+    stopIfWorker,
+    onWorkerSnapshot,
+    destroyEngine,
+  }
+}

--- a/src/frontend/src/redvsblue/rendererManager.ts
+++ b/src/frontend/src/redvsblue/rendererManager.ts
@@ -1,0 +1,146 @@
+import type { GameState } from "@/redvsblue/types"
+
+import { CanvasRenderer } from "@/redvsblue/renderer"
+import { applyCanvasSize } from "@copilot-playground/shared"
+import type { EngineWithWorkerControls } from "@/redvsblue/engineManager"
+
+export type SnapshotSelector<TState> = (state: TState) => GameState | null
+export type SnapshotSubscriber<TState> = (
+  selector: SnapshotSelector<TState>,
+  listener: (snapshot: GameState | null) => void
+) => () => void
+
+export type RendererManagerOptions = {
+  canvas: HTMLCanvasElement
+  container?: Element | null
+  engine: EngineWithWorkerControls
+  worker: boolean
+  selectedRenderer: string
+  onFallbackToCanvas?: () => void
+  rendererFactory?: () => CanvasRenderer
+}
+
+export type RendererManager = {
+  configureCanvas: () => { width: number; height: number } | null
+  initRenderer: () => CanvasRenderer | null
+  subscribeToSnapshots: <TState>(subscribe: SnapshotSubscriber<TState>, selector: SnapshotSelector<TState>) => () => void
+  observeResize: (onResize: () => void) => () => void
+  destroyRenderer: () => void
+  reset: () => void
+}
+
+type CanvasTransfer = { transferControlToOffscreen?: () => OffscreenCanvas }
+type CanvasResizer = { resizeCanvas: (width: number, height: number) => void }
+type CanvasSetter = { setCanvas: (canvas: OffscreenCanvas, width: number, height: number) => void }
+
+const hasResizeCanvas = (engine: EngineWithWorkerControls): engine is EngineWithWorkerControls & CanvasResizer => {
+  return typeof (engine as CanvasResizer).resizeCanvas === "function"
+}
+
+const hasSetCanvas = (engine: EngineWithWorkerControls): engine is EngineWithWorkerControls & CanvasSetter => {
+  return typeof (engine as CanvasSetter).setCanvas === "function"
+}
+
+export function getCanvasSize(
+  canvas: HTMLCanvasElement,
+  container?: Element | null
+): { width: number; height: number } {
+  const el = container ?? canvas.parentElement
+  const width = el instanceof HTMLElement ? el.clientWidth : canvas.clientWidth ?? 0
+  const height = el instanceof HTMLElement ? el.clientHeight : canvas.clientHeight ?? 0
+  return { width, height }
+}
+
+export function createRendererManager(options: RendererManagerOptions): RendererManager {
+  const {
+    canvas,
+    container,
+    engine,
+    worker,
+    selectedRenderer,
+    onFallbackToCanvas,
+    rendererFactory = () => new CanvasRenderer(),
+  } = options
+
+  const wantOffscreen = worker && selectedRenderer === "offscreen"
+  const offscreenSupported =
+    wantOffscreen &&
+    typeof (canvas as CanvasTransfer).transferControlToOffscreen === "function" &&
+    typeof OffscreenCanvas !== "undefined"
+
+  const useOffscreen = Boolean(offscreenSupported)
+  let renderer: CanvasRenderer | null = null
+  let offscreenCanvas: OffscreenCanvas | null = null
+
+  const initRenderer = (): CanvasRenderer | null => {
+    if (useOffscreen) return null
+    if (!renderer) {
+      renderer = rendererFactory()
+    }
+    renderer.init(canvas)
+    return renderer
+  }
+
+  const configureCanvas = (): { width: number; height: number } | null => {
+    const { width, height } = getCanvasSize(canvas, container)
+    applyCanvasSize(canvas, width, height)
+
+    if (useOffscreen) {
+      if (!offscreenCanvas) {
+        try {
+          const offscreen = (canvas as CanvasTransfer).transferControlToOffscreen!()
+          offscreenCanvas = offscreen
+          if (hasSetCanvas(engine)) {
+            engine.setCanvas(offscreen, canvas.width, canvas.height)
+          }
+        } catch (err) {
+          onFallbackToCanvas?.()
+          return null
+        }
+      } else if (hasResizeCanvas(engine)) {
+        engine.resizeCanvas(canvas.width, canvas.height)
+      }
+    }
+
+    return { width: canvas.width, height: canvas.height }
+  }
+
+  const subscribeToSnapshots = <TState>(
+    subscribe: SnapshotSubscriber<TState>,
+    selector: SnapshotSelector<TState>
+  ): (() => void) => {
+    if (!renderer) return () => {}
+    return subscribe(selector, (snapshot) => {
+      renderer?.render(snapshot)
+    })
+  }
+
+  const observeResize = (onResize: () => void): (() => void) => {
+    const resizeObserver = new ResizeObserver(() => {
+      onResize()
+    })
+
+    if (container) resizeObserver.observe(container)
+
+    return () => resizeObserver.disconnect()
+  }
+
+  const destroyRenderer = (): void => {
+    renderer?.destroy()
+    renderer = null
+  }
+
+  const reset = (): void => {
+    destroyRenderer()
+    offscreenCanvas = null
+  }
+
+  return {
+    configureCanvas,
+    initRenderer,
+    subscribeToSnapshots,
+    observeResize,
+    destroyRenderer,
+    reset,
+  }
+}

--- a/src/frontend/src/redvsblue/telemetryForwarder.ts
+++ b/src/frontend/src/redvsblue/telemetryForwarder.ts
@@ -1,0 +1,32 @@
+import type { EngineConfig, TelemetryEvent } from "@/redvsblue/types"
+import type { EngineWithWorkerControls } from "@/redvsblue/engineManager"
+
+export type TelemetryForwarderOptions = {
+  engine: EngineWithWorkerControls
+  config: Omit<EngineConfig, "canvasWidth" | "canvasHeight">
+  onTelemetry: (event: TelemetryEvent) => void
+  getUiEnabled: () => boolean
+  onError?: (error: unknown) => void
+}
+
+export function attachTelemetryForwarder(options: TelemetryForwarderOptions): () => void {
+  const { engine, config, onTelemetry, getUiEnabled, onError } = options
+
+  const handler = (data: unknown) => {
+    try {
+      const engineEnabled = config.enableTelemetry ?? true
+      const uiEnabled = getUiEnabled() ?? true
+      if (!engineEnabled || !uiEnabled) return
+      onTelemetry(data as TelemetryEvent)
+    } catch (error) {
+      if (onError) {
+        onError(error)
+      } else {
+        console.error("telemetry handler error", error)
+      }
+    }
+  }
+
+  engine.on("telemetry", handler)
+  return () => engine.off("telemetry", handler)
+}

--- a/src/frontend/src/redvsblue/useFps.ts
+++ b/src/frontend/src/redvsblue/useFps.ts
@@ -1,0 +1,55 @@
+import { useCallback, useRef } from "react"
+
+export type UseFpsOptions = {
+  windowMs?: number
+  publishIntervalMs?: number
+}
+
+export type UseFpsResult = {
+  reset: (now?: number) => void
+  recordFrame: (now: number) => number | null
+}
+
+export function useFps(options: UseFpsOptions = {}): UseFpsResult {
+  const { windowMs = 500, publishIntervalMs = 250 } = options
+
+  const framesRef = useRef(0)
+  const windowStartRef = useRef(0)
+  const lastPublishRef = useRef(0)
+
+  const reset = useCallback((now?: number) => {
+    framesRef.current = 0
+    if (typeof now === "number") {
+      windowStartRef.current = now
+      lastPublishRef.current = now
+      return
+    }
+    windowStartRef.current = 0
+    lastPublishRef.current = 0
+  }, [])
+
+  const recordFrame = useCallback(
+    (now: number) => {
+      if (windowStartRef.current === 0) {
+        windowStartRef.current = now
+        lastPublishRef.current = now
+        framesRef.current = 0
+      }
+
+      framesRef.current += 1
+      const windowElapsed = now - windowStartRef.current
+      const publishElapsed = now - lastPublishRef.current
+      if (windowElapsed >= windowMs && publishElapsed >= publishIntervalMs) {
+        const fps = Math.round((framesRef.current * 1000) / windowElapsed)
+        windowStartRef.current = now
+        lastPublishRef.current = now
+        framesRef.current = 0
+        return fps
+      }
+      return null
+    },
+    [publishIntervalMs, windowMs]
+  )
+
+  return { reset, recordFrame }
+}

--- a/tests/frontend/unit/redvsblue/engineManager.test.ts
+++ b/tests/frontend/unit/redvsblue/engineManager.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createEngineManager, type EngineRef, type EngineWithWorkerControls } from "@/redvsblue/engineManager"
+import type { EngineConfig, GameState } from "@/redvsblue/types"
+
+const baseConfig: EngineConfig = {
+  canvasWidth: 320,
+  canvasHeight: 200,
+  shipSpeed: 4,
+  bulletSpeed: 7,
+  bulletDamage: 2,
+  shipMaxHealth: 12,
+  enableTelemetry: false,
+}
+
+const snapshot: GameState = {
+  ships: [],
+  bullets: [],
+  particles: [],
+  stars: [],
+  timestamp: 0,
+}
+
+const createEngineStub = () => {
+  const listeners = new Map<string, Set<(data: unknown) => void>>()
+
+  const engine: EngineWithWorkerControls = {
+    init: vi.fn(),
+    update: vi.fn(),
+    getState: vi.fn(() => snapshot),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: (data: unknown) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(handler)
+    }),
+    off: vi.fn((event: string, handler: (data: unknown) => void) => {
+      listeners.get(event)?.delete(handler)
+    }),
+    emit: vi.fn((event: string, data: unknown) => {
+      listeners.get(event)?.forEach((h) => h(data))
+    }),
+    spawnShip: vi.fn(),
+    reset: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+
+  return engine
+}
+
+describe("engineManager", () => {
+  it("uses engineFactory for main-thread engine and updates snapshots", () => {
+    const engine = createEngineStub()
+    const engineFactory = vi.fn(() => engine)
+    const engineRef: EngineRef = { current: null }
+
+    const manager = createEngineManager({ engineRef, worker: false, engineFactory })
+
+    manager.ensureEngine()
+    expect(engineFactory).toHaveBeenCalledTimes(1)
+
+    const onSnapshot = vi.fn()
+    manager.updateEngine(16, onSnapshot)
+
+    expect(engine.update).toHaveBeenCalledWith(16)
+    expect(onSnapshot).toHaveBeenCalledWith(snapshot)
+
+    manager.startIfWorker()
+    manager.stopIfWorker()
+    expect(engine.start).not.toHaveBeenCalled()
+    expect(engine.stop).not.toHaveBeenCalled()
+  })
+
+  it("uses workerFactory in worker mode and calls start/stop", () => {
+    const engine = createEngineStub()
+    const workerFactory = vi.fn(() => engine)
+    const engineRef: EngineRef = { current: null }
+
+    const manager = createEngineManager({
+      engineRef,
+      worker: true,
+      workerTickHz: 20,
+      workerSnapshotHz: 10,
+      workerFactory,
+    })
+
+    manager.ensureEngine()
+    expect(workerFactory).toHaveBeenCalledWith({ tickHz: 20, snapshotHz: 10 })
+
+    manager.startIfWorker()
+    manager.stopIfWorker()
+
+    expect(engine.start).toHaveBeenCalledTimes(1)
+    expect(engine.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("attaches and removes worker snapshot handler", () => {
+    const engine = createEngineStub()
+    const engineRef: EngineRef = { current: engine }
+    const manager = createEngineManager({ engineRef, worker: true })
+
+    const handler = vi.fn()
+    const unsubscribe = manager.onWorkerSnapshot(handler)
+
+    engine.emit("snapshot", snapshot)
+    expect(handler).toHaveBeenCalledWith(snapshot)
+
+    unsubscribe()
+    engine.emit("snapshot", { ...snapshot, timestamp: 1 })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it("resets engine and snapshots when not in worker mode", () => {
+    const engine = createEngineStub()
+    const engineRef: EngineRef = { current: engine }
+    const manager = createEngineManager({ engineRef, worker: false })
+
+    const onSnapshot = vi.fn()
+    manager.resetEngine(onSnapshot)
+
+    expect(engine.reset).toHaveBeenCalledTimes(1)
+    expect(onSnapshot).toHaveBeenCalledWith(snapshot)
+  })
+
+  it("initializes engine with provided config", () => {
+    const engine = createEngineStub()
+    const engineRef: EngineRef = { current: engine }
+    const manager = createEngineManager({ engineRef, worker: false })
+
+    manager.initEngine(baseConfig)
+    expect(engine.init).toHaveBeenCalledWith(baseConfig)
+  })
+})

--- a/tests/frontend/unit/redvsblue/rendererManager.test.ts
+++ b/tests/frontend/unit/redvsblue/rendererManager.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createRendererManager } from "@/redvsblue/rendererManager"
+import type { EngineWithWorkerControls } from "@/redvsblue/engineManager"
+
+const createEngineStub = (): EngineWithWorkerControls => ({
+  init: vi.fn(),
+  update: vi.fn(),
+  getState: vi.fn(),
+  destroy: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  spawnShip: vi.fn(),
+  reset: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  setCanvas: vi.fn(),
+  resizeCanvas: vi.fn(),
+})
+
+const setContainerSize = (container: HTMLElement, width: number, height: number): void => {
+  Object.defineProperty(container, "clientWidth", { value: width, configurable: true })
+  Object.defineProperty(container, "clientHeight", { value: height, configurable: true })
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { OffscreenCanvas?: unknown }).OffscreenCanvas
+})
+
+describe("rendererManager", () => {
+  it("transfers offscreen canvas and resizes on subsequent configure", () => {
+    ;(globalThis as unknown as { OffscreenCanvas?: unknown }).OffscreenCanvas = class {}
+
+    const engine = createEngineStub()
+    const container = document.createElement("div")
+    setContainerSize(container, 800, 600)
+
+    const canvas = document.createElement("canvas") as HTMLCanvasElement & {
+      transferControlToOffscreen?: () => OffscreenCanvas
+    }
+    const offscreen = { width: 0, height: 0 } as OffscreenCanvas
+    canvas.transferControlToOffscreen = vi.fn(() => offscreen)
+
+    const manager = createRendererManager({
+      canvas,
+      container,
+      engine,
+      worker: true,
+      selectedRenderer: "offscreen",
+    })
+
+    const size = manager.configureCanvas()
+
+    expect(size).toEqual({ width: 800, height: 600 })
+    expect(engine.setCanvas).toHaveBeenCalledWith(offscreen, 800, 600)
+
+    setContainerSize(container, 1024, 768)
+    manager.configureCanvas()
+
+    expect(engine.resizeCanvas).toHaveBeenCalledWith(1024, 768)
+  })
+
+  it("falls back when offscreen transfer fails", () => {
+    ;(globalThis as unknown as { OffscreenCanvas?: unknown }).OffscreenCanvas = class {}
+
+    const engine = createEngineStub()
+    const container = document.createElement("div")
+    setContainerSize(container, 400, 300)
+
+    const canvas = document.createElement("canvas") as HTMLCanvasElement & {
+      transferControlToOffscreen?: () => OffscreenCanvas
+    }
+    canvas.transferControlToOffscreen = vi.fn(() => {
+      throw new Error("transfer failed")
+    })
+
+    const onFallback = vi.fn()
+    const manager = createRendererManager({
+      canvas,
+      container,
+      engine,
+      worker: true,
+      selectedRenderer: "offscreen",
+      onFallbackToCanvas: onFallback,
+    })
+
+    const size = manager.configureCanvas()
+
+    expect(size).toBeNull()
+    expect(onFallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/frontend/unit/redvsblue/telemetryForwarder.test.ts
+++ b/tests/frontend/unit/redvsblue/telemetryForwarder.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { attachTelemetryForwarder } from "@/redvsblue/telemetryForwarder"
+import type { EngineWithWorkerControls } from "@/redvsblue/engineManager"
+import type { EngineConfig, TelemetryEvent } from "@/redvsblue/types"
+
+const createEngineStub = () => {
+  const listeners = new Map<string, Set<(data: unknown) => void>>()
+
+  const engine: EngineWithWorkerControls = {
+    init: vi.fn(),
+    update: vi.fn(),
+    getState: vi.fn(),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: (data: unknown) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(handler)
+    }),
+    off: vi.fn((event: string, handler: (data: unknown) => void) => {
+      listeners.get(event)?.delete(handler)
+    }),
+    emit: vi.fn((event: string, data: unknown) => {
+      listeners.get(event)?.forEach((h) => h(data))
+    }),
+    spawnShip: vi.fn(),
+    reset: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+
+  return engine
+}
+
+const baseConfig: Omit<EngineConfig, "canvasWidth" | "canvasHeight"> = {
+  shipSpeed: 4,
+  bulletSpeed: 7,
+  bulletDamage: 2,
+  shipMaxHealth: 12,
+  enableTelemetry: true,
+}
+
+describe("telemetryForwarder", () => {
+  it("forwards telemetry when enabled", () => {
+    const engine = createEngineStub()
+    const onTelemetry = vi.fn()
+    const getUiEnabled = vi.fn(() => true)
+
+    const cleanup = attachTelemetryForwarder({
+      engine,
+      config: baseConfig,
+      onTelemetry,
+      getUiEnabled,
+    })
+
+    const evt: TelemetryEvent = { type: "unit", timestamp: 1, data: {} }
+    engine.emit("telemetry", evt)
+
+    expect(onTelemetry).toHaveBeenCalledWith(evt)
+    cleanup()
+  })
+
+  it("gates telemetry when UI toggle disabled", () => {
+    const engine = createEngineStub()
+    const onTelemetry = vi.fn()
+    const getUiEnabled = vi.fn(() => false)
+
+    attachTelemetryForwarder({
+      engine,
+      config: baseConfig,
+      onTelemetry,
+      getUiEnabled,
+    })
+
+    engine.emit("telemetry", { type: "unit", timestamp: 1, data: {} })
+    expect(onTelemetry).not.toHaveBeenCalled()
+  })
+
+  it("gates telemetry when engine config disabled", () => {
+    const engine = createEngineStub()
+    const onTelemetry = vi.fn()
+    const getUiEnabled = vi.fn(() => true)
+
+    attachTelemetryForwarder({
+      engine,
+      config: { ...baseConfig, enableTelemetry: false },
+      onTelemetry,
+      getUiEnabled,
+    })
+
+    engine.emit("telemetry", { type: "unit", timestamp: 1, data: {} })
+    expect(onTelemetry).not.toHaveBeenCalled()
+  })
+
+  it("removes handler on cleanup", () => {
+    const engine = createEngineStub()
+    const onTelemetry = vi.fn()
+
+    const cleanup = attachTelemetryForwarder({
+      engine,
+      config: baseConfig,
+      onTelemetry,
+      getUiEnabled: () => true,
+    })
+
+    cleanup()
+    engine.emit("telemetry", { type: "unit", timestamp: 1, data: {} })
+    expect(onTelemetry).not.toHaveBeenCalled()
+  })
+
+  it("calls onError when handler throws", () => {
+    const engine = createEngineStub()
+    const onError = vi.fn()
+
+    attachTelemetryForwarder({
+      engine,
+      config: baseConfig,
+      onTelemetry: () => {
+        throw new Error("boom")
+      },
+      getUiEnabled: () => true,
+      onError,
+    })
+
+    engine.emit("telemetry", { type: "unit", timestamp: 1, data: {} })
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/frontend/unit/redvsblue/useFps.test.tsx
+++ b/tests/frontend/unit/redvsblue/useFps.test.tsx
@@ -1,0 +1,47 @@
+import React, { useLayoutEffect } from "react"
+import { describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
+
+import { useFps, type UseFpsResult } from "@/redvsblue/useFps"
+
+const FpsHarness = ({ onReady }: { onReady: (api: UseFpsResult) => void }) => {
+  const api = useFps({ windowMs: 500, publishIntervalMs: 250 })
+
+  useLayoutEffect(() => {
+    onReady(api)
+  }, [api, onReady])
+
+  return null
+}
+
+describe("useFps", () => {
+  it("publishes fps once thresholds are met", () => {
+    let api: UseFpsResult | null = null
+
+    render(<FpsHarness onReady={(value) => { api = value }} />)
+
+    expect(api).not.toBeNull()
+    api!.reset()
+
+    expect(api!.recordFrame(1000)).toBeNull()
+    expect(api!.recordFrame(1100)).toBeNull()
+    expect(api!.recordFrame(1200)).toBeNull()
+    expect(api!.recordFrame(1300)).toBeNull()
+
+    const fps = api!.recordFrame(1500)
+    expect(fps).toBe(10)
+  })
+
+  it("resets window with explicit timestamp", () => {
+    let api: UseFpsResult | null = null
+
+    render(<FpsHarness onReady={(value) => { api = value }} />)
+
+    expect(api).not.toBeNull()
+    api!.reset(2000)
+
+    expect(api!.recordFrame(2000)).toBeNull()
+    const fps = api!.recordFrame(2500)
+    expect(fps).toBe(4)
+  })
+})


### PR DESCRIPTION
The refactor splits the backend monolithic `app.ts` into dedicated routes, controllers, schemas, and logging modules, enhancing organization and maintainability. The frontend `useGame` hook is simplified by extracting engine, renderer, and telemetry responsibilities into separate modules. This restructuring improves testability and reduces cognitive load while ensuring existing functionality remains unchanged. Unit and integration tests have been added to cover the new module structures.

Fixes #82, #83