### PR TITLE
Revisit .env handling for Docker builds

### DIFF
--- a/src/copilot/package.json
+++ b/src/copilot/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "dotenvx run -- tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "dotenvx run -- node dist/index.js",
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage"
@@ -15,7 +15,6 @@
     "@copilot-playground/shared": "workspace:*",
     "@github/copilot": "^0.0.394",
     "@github/copilot-sdk": "^0.1.17",
-    "dotenv": "^17.2.3",
     "@dotenvx/dotenvx": "^1.52.0",
     "express": "^5.2.1",
     "zod": "^4.3.6"

--- a/src/copilot/src/index.ts
+++ b/src/copilot/src/index.ts
@@ -1,4 +1,9 @@
-import "dotenv/config"; // loads .env for local development. TODO: revisit .env handling for Docker builds (inject envs into container at runtime)
+/**
+ * Load environment variables.
+ * In local development, we use `dotenvx run` via package.json scripts to load .env files.
+ * In Docker/Production, environment variables are injected at runtime (e.g., via Docker Secrets
+ * or orchestrator environment variables). See src/copilot/entrypoint.sh for details.
+ */
 import crypto from "node:crypto";
 import express from "express";
 import { z } from "zod";


### PR DESCRIPTION
This change refactors how the copilot service handles environment variables to better support Docker builds and production environments.

Previously, the application relied on `import "dotenv/config"` in the code, which looks for a `.env` file that is excluded from Docker images. This made it difficult to inject variables at runtime without a mounted file.

The new approach:
1.  **Removes code-level environment loading:** The application now starts by consuming whatever is already in `process.env`.
2.  **Uses `dotenvx run` via scripts:** For local development, `pnpm dev` now uses `dotenvx run` to load `.env` (and decrypt it if necessary). This keeps the code clean and decouples it from environment management.
3.  **Supports runtime injection:** In Docker, the `entrypoint.sh` already handles secret injection. This change ensures that the application seamlessly picks up those variables.
4.  **Improves security:** Follows the project's "secrets-first" pattern by allowing the use of encrypted `.env` files and runtime key injection.

Verified the code changes and verified that no `dotenv` imports remain in the source code. Tests were attempted but limited by the sandbox environment's lack of network/dependencies.

---
*PR created automatically by Jules for task [15738182362334232426](https://jules.google.com/task/15738182362334232426) started by @deadronos*